### PR TITLE
Enable screen readers for visually impaired to read text

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Contributions of all kind are welcome, please get in touch with us!
 * Update bills
 * Delete bills
 * Clearing debt of single members
-* C̵r̵e̵a̵t̵i̵n̵g̵ ̵n̵e̵w̵ ̵p̵r̵o̵j̵e̵c̵t̵s̵ ̵o̵n̵ ̵i̵H̵a̵t̵e̵M̵o̵n̵e̵y̵
+* ~Creating new projects on iHateMoney~
 * Adding new members to a project
 
 


### PR DESCRIPTION
Use proper markdown strikethrough (~): “special” unicode characters often are not recognized by screen readers.

> screen readers treat special characters differently to the standard
alphabet. This can cause issues as assistive technologies cannot always ‘read’ them. Sometimes they will skip them altogether.

https://business.scope.org.uk/article/accessibility-screen-readers-special-characters-and-unicode-symbols/