### PR TITLE
Deterministic order of members in 'Add bill' screen

### DIFF
--- a/PayForMe/Views/BillDetail/BillDetailView.swift
+++ b/PayForMe/Views/BillDetail/BillDetailView.swift
@@ -37,7 +37,7 @@ struct BillDetailView: View {
         VStack {
             Form {
                 Section(header: Text("Payer")) {
-                    WhoPaidView(members: Array(viewModel.currentProject.members.values), selectedPayer: self.$viewModel.selectedPayer).onAppear {
+                    WhoPaidView(members: Array(viewModel.currentProject.members.values).sorted{ $0.name < $1.name }, selectedPayer: self.$viewModel.selectedPayer).onAppear {
                         if self.viewModel.currentProject.members[self.viewModel.selectedPayer] == nil {
                             guard let id = self.viewModel.currentProject.members.first?.key else { return }
                             self.viewModel.selectedPayer = id


### PR DESCRIPTION
Hi! I love this app 💛 We use it a lot in our household :) Thank you so much for developing and maintaining it!

One minor thing that causes complaints in our household regularly is that the order of the members in the "Payer" section fo the "Add bill" screen is non-deterministic, i.e., it can be different on separate opens of the screen. (We use it with iHateMoney as backend.)

I digged into the code and think I found a way to fix this. I am not an iOS developer, so there might very well be a better way to do this. I am very willing to change my pull request based on feedback. I would love to see this minor gripe for us fixed 🙂

(According to reports from my household, which of the members is pre-selected for payment also seems to be non-deterministic, but unfortunately I do not understand how the code that does this (seems to be the lines following my change) works.) 