### PR TITLE
feat: Add offline mode with local caching and sync

### DIFF
--- a/PayForMe.xcodeproj/project.pbxproj
+++ b/PayForMe.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+	BILLMERGE_TESTS_BUILD /* BillMergeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BILLMERGE_TESTS_REF /* BillMergeTests.swift */; };
 		481FB4FB23E964C8003BD108 /* ProjectManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FB4FA23E964C8003BD108 /* ProjectManager.swift */; };
 		481FB4FD23EAD78F003BD108 /* AddProjectManualViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 481FB4FC23EAD78F003BD108 /* AddProjectManualViewModel.swift */; };
 		489995DA23F6EC6F008B7E38 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489995D923F6EC6F008B7E38 /* OnboardingView.swift */; };
@@ -27,6 +28,7 @@
 		654754BC2528750A00A82EB6 /* FloatingAddButtonViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654754BB2528750A00A82EB6 /* FloatingAddButtonViewModifier.swift */; };
 		654754C0252889B200A82EB6 /* ProjectQRPermissionCheckerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654754BF252889B200A82EB6 /* ProjectQRPermissionCheckerView.swift */; };
 		654754C8252899FF00A82EB6 /* FancyButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654754C7252899FF00A82EB6 /* FancyButton.swift */; };
+		654754CA25289A0200A82EB6 /* OfflineStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654754C925289A0200A82EB6 /* OfflineStatusView.swift */; };
 		654754E42528B29F00A82EB6 /* AddProjectManuallyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654754E32528B29F00A82EB6 /* AddProjectManuallyTests.swift */; };
 		654754F22528BB7700A82EB6 /* ShareProjectQRCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654754F12528BB7600A82EB6 /* ShareProjectQRCode.swift */; };
 		655DD2AE2993DACB00E06675 /* ProjectListEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 655DD2AD2993DACB00E06675 /* ProjectListEntry.swift */; };
@@ -81,6 +83,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+	BILLMERGE_TESTS_REF /* BillMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillMergeTests.swift; sourceTree = "<group>"; };
 		481FB4FA23E964C8003BD108 /* ProjectManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectManager.swift; sourceTree = "<group>"; };
 		481FB4FC23EAD78F003BD108 /* AddProjectManualViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProjectManualViewModel.swift; sourceTree = "<group>"; };
 		489995D923F6EC6F008B7E38 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -101,6 +104,7 @@
 		654754BB2528750A00A82EB6 /* FloatingAddButtonViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatingAddButtonViewModifier.swift; sourceTree = "<group>"; };
 		654754BF252889B200A82EB6 /* ProjectQRPermissionCheckerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProjectQRPermissionCheckerView.swift; sourceTree = "<group>"; };
 		654754C7252899FF00A82EB6 /* FancyButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FancyButton.swift; sourceTree = "<group>"; };
+		654754C925289A0200A82EB6 /* OfflineStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineStatusView.swift; sourceTree = "<group>"; };
 		654754E12528B29F00A82EB6 /* PayForMeTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PayForMeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		654754E32528B29F00A82EB6 /* AddProjectManuallyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProjectManuallyTests.swift; sourceTree = "<group>"; };
 		654754E52528B29F00A82EB6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -204,6 +208,7 @@
 				6596D4E223ED9C520079DD5B /* BillDetail */,
 				65662A0623D7320000303207 /* ContentView.swift */,
 				654754C7252899FF00A82EB6 /* FancyButton.swift */,
+				654754C925289A0200A82EB6 /* OfflineStatusView.swift */,
 				650504A023FEA461000E5F9C /* PersonText.swift */,
 				48E7F75A2403FD6B000CE4E6 /* FancyLoadingButton.swift */,
 			);
@@ -213,9 +218,10 @@
 		654754E22528B29F00A82EB6 /* PayForMeTests */ = {
 			isa = PBXGroup;
 			children = (
-				654754E32528B29F00A82EB6 /* AddProjectManuallyTests.swift */,
-				654754E52528B29F00A82EB6 /* Info.plist */,
-				6523FC4B25580EEF00BCD843 /* UrlExtensionsTests.swift */,
+				   654754E32528B29F00A82EB6 /* AddProjectManuallyTests.swift */,
+				   654754E52528B29F00A82EB6 /* Info.plist */,
+				   6523FC4B25580EEF00BCD843 /* UrlExtensionsTests.swift */,
+				   BILLMERGE_TESTS_REF /* BillMergeTests.swift */,
 			);
 			path = PayForMeTests;
 			sourceTree = "<group>";
@@ -522,8 +528,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				654754E42528B29F00A82EB6 /* AddProjectManuallyTests.swift in Sources */,
-				6523FC4C25580EEF00BCD843 /* UrlExtensionsTests.swift in Sources */,
+				   654754E42528B29F00A82EB6 /* AddProjectManuallyTests.swift in Sources */,
+				   6523FC4C25580EEF00BCD843 /* UrlExtensionsTests.swift in Sources */,
+				   BILLMERGE_TESTS_BUILD /* BillMergeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -532,6 +539,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				654754C8252899FF00A82EB6 /* FancyButton.swift in Sources */,
+				654754CA25289A0200A82EB6 /* OfflineStatusView.swift in Sources */,
 				656E8CB423D9C3DA00B3ED10 /* BillDetailView.swift in Sources */,
 				481FB4FB23E964C8003BD108 /* ProjectManager.swift in Sources */,
 				654754F22528BB7700A82EB6 /* ShareProjectQRCode.swift in Sources */,

--- a/PayForMe/Model/Project.swift
+++ b/PayForMe/Model/Project.swift
@@ -7,7 +7,41 @@
 
 import Foundation
 
-class Project: Codable, Identifiable {
+import Combine
+
+class Project: Identifiable, ObservableObject, Codable {
+    enum CodingKeys: String, CodingKey {
+        case name, password, token, url, id, backend, members, bills, me
+    }
+
+    required convenience init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let name = try container.decode(String.self, forKey: .name)
+        let password = try container.decode(String.self, forKey: .password)
+        let token = try container.decode(String.self, forKey: .token)
+        let url = try container.decode(URL.self, forKey: .url)
+        let id = try container.decodeIfPresent(Int.self, forKey: .id)
+        let backend = try container.decode(ProjectBackend.self, forKey: .backend)
+        let members = try container.decode([Int: Person].self, forKey: .members)
+        let bills = try container.decode([Bill].self, forKey: .bills)
+        let me = try container.decodeIfPresent(Int.self, forKey: .me)
+        self.init(name: name, password: password, token: token, backend: backend, url: url, id: id, me: me)
+        self.members = members
+        self.bills = bills
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        try container.encode(password, forKey: .password)
+        try container.encode(token, forKey: .token)
+        try container.encode(url, forKey: .url)
+        try container.encode(id, forKey: .id)
+        try container.encode(backend, forKey: .backend)
+        try container.encode(members, forKey: .members)
+        try container.encode(bills, forKey: .bills)
+        try container.encode(me, forKey: .me)
+    }
     let name: String
     let password: String
     let token: String
@@ -15,8 +49,8 @@ class Project: Codable, Identifiable {
     let id: Int?
     let backend: ProjectBackend
 
-    var members: [Int: Person]
-    var bills: [Bill]
+    @Published var members: [Int: Person]
+    @Published var bills: [Bill]
     var me: Int?
 
     convenience init(name: String, password: String, token: String, backend: ProjectBackend, url: URL) {
@@ -30,8 +64,8 @@ class Project: Codable, Identifiable {
         self.backend = backend
         self.url = url
         self.id = id
-        members = [:]
-        bills = []
+        self.members = [:]
+        self.bills = []
         self.me = me
     }
 }

--- a/PayForMe/SceneDelegate.swift
+++ b/PayForMe/SceneDelegate.swift
@@ -46,6 +46,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneDidBecomeActive(_: UIScene) {
         // Called when the scene has moved from an inactive state to an active state.
         // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+        
+        // Automatically sync data when app becomes active for transparent offline experience
+        Task {
+            await ProjectManager.shared.syncData()
+        }
     }
 
     func sceneWillResignActive(_: UIScene) {
@@ -56,6 +61,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func sceneWillEnterForeground(_: UIScene) {
         // Called as the scene transitions from the background to the foreground.
         // Use this method to undo the changes made on entering the background.
+        
+        // Sync data when returning from background
+        Task {
+            await ProjectManager.shared.syncData()
+        }
     }
 
     func sceneDidEnterBackground(_: UIScene) {

--- a/PayForMe/Services/NetworkService.swift
+++ b/PayForMe/Services/NetworkService.swift
@@ -32,9 +32,23 @@ class NetworkService {
     func loadBillsPublisher(_ project: Project) -> AnyPublisher<[Bill], Never> {
         let request = buildURLRequest("bills", params: [:], project: project)
         return URLSession.shared.dataTaskPublisher(for: request)
+            .handleEvents(
+                receiveSubscription: { _ in
+                    self.networkActivityPublisher.send(true)
+                },
+                receiveCompletion: { _ in
+                    self.networkActivityPublisher.send(false)
+                }
+            )
             .compactMap { data, response -> Data? in
-                guard let httpResponse = response as? HTTPURLResponse else { print("Network Error"); return nil }
-                guard httpResponse.statusCode == 200 else { print("Network Error: Status code: \(httpResponse.statusCode) \(httpResponse.description)"); return nil }
+                guard let httpResponse = response as? HTTPURLResponse else { 
+                    print("Network Error: No HTTP response")
+                    return nil 
+                }
+                guard httpResponse.statusCode == 200 else { 
+                    print("Network Error: Status code: \(httpResponse.statusCode) \(httpResponse.description)")
+                    return nil 
+                }
                 return data
             }
             .decode(type: [Bill].self, decoder: decoder)
@@ -55,9 +69,23 @@ class NetworkService {
     func loadMembersPublisher(_ project: Project) -> AnyPublisher<[Int: Person], Never> {
         let request = buildURLRequest("members", params: [:], project: project)
         return URLSession.shared.dataTaskPublisher(for: request)
+            .handleEvents(
+                receiveSubscription: { _ in
+                    self.networkActivityPublisher.send(true)
+                },
+                receiveCompletion: { _ in
+                    self.networkActivityPublisher.send(false)
+                }
+            )
             .compactMap { data, response -> Data? in
-                guard let httpResponse = response as? HTTPURLResponse else { print("Network Error"); return nil }
-                guard httpResponse.statusCode == 200 else { print("Network Error: Status code: \(httpResponse.statusCode) \(httpResponse.description)"); return nil }
+                guard let httpResponse = response as? HTTPURLResponse else { 
+                    print("Network Error: No HTTP response")
+                    return nil 
+                }
+                guard httpResponse.statusCode == 200 else { 
+                    print("Network Error: Status code: \(httpResponse.statusCode) \(httpResponse.description)")
+                    return nil 
+                }
                 return data
             }
             .decode(type: [Person].self, decoder: decoder)
@@ -69,6 +97,66 @@ class NetworkService {
                 }
                 return Dictionary(filtered.map { ($0.id, $0) }) { a, _ in a }
             }
+            .eraseToAnyPublisher()
+    }
+    
+    // MARK: - Result-based publishers for offline handling
+    
+    func loadBillsWithStatusPublisher(_ project: Project) -> AnyPublisher<Result<[Bill], Error>, Never> {
+        let request = buildURLRequest("bills", params: [:], project: project)
+        return URLSession.shared.dataTaskPublisher(for: request)
+            .handleEvents(
+                receiveSubscription: { _ in
+                    self.networkActivityPublisher.send(true)
+                },
+                receiveCompletion: { _ in
+                    self.networkActivityPublisher.send(false)
+                }
+            )
+            .tryMap { data, response -> [Bill] in
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw NetworkError.noResponse
+                }
+                guard httpResponse.statusCode == 200 else {
+                    throw NetworkError.statusCode(httpResponse.statusCode)
+                }
+                let bills = try self.decoder.decode([Bill].self, from: data)
+                return bills.sorted {
+                    if let l1 = $0.lastchanged, let l2 = $1.lastchanged {
+                        return l1 > l2
+                    }
+                    return $0.date > $1.date
+                }
+            }
+            .map { Result.success($0) }
+            .catch { Just(Result.failure($0)) }
+            .eraseToAnyPublisher()
+    }
+    
+    func loadMembersWithStatusPublisher(_ project: Project) -> AnyPublisher<Result<[Int: Person], Error>, Never> {
+        let request = buildURLRequest("members", params: [:], project: project)
+        return URLSession.shared.dataTaskPublisher(for: request)
+            .handleEvents(
+                receiveSubscription: { _ in
+                    self.networkActivityPublisher.send(true)
+                },
+                receiveCompletion: { _ in
+                    self.networkActivityPublisher.send(false)
+                }
+            )
+            .tryMap { data, response -> [Int: Person] in
+                guard let httpResponse = response as? HTTPURLResponse else {
+                    throw NetworkError.noResponse
+                }
+                guard httpResponse.statusCode == 200 else {
+                    throw NetworkError.statusCode(httpResponse.statusCode)
+                }
+                let members = try self.decoder.decode([Person].self, from: data)
+                let filtered = members.filter { $0.activated }
+                return Dictionary(filtered.map { ($0.id, $0) }) { a, _ in a }
+            }
+            .map { Result.success($0) }
+            .catch { Just(Result.failure($0)) }
             .eraseToAnyPublisher()
     }
 
@@ -195,9 +283,152 @@ class NetworkService {
 
         return request
     }
+    
+    // MARK: - Async/Await Methods for Sync
+    
+    func loadBills(_ project: Project) async throws -> [Bill] {
+        let request = buildURLRequest("bills", params: [:], project: project)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            throw NetworkError.statusCode(httpResponse.statusCode)
+        }
+        
+        let bills = try decoder.decode([Bill].self, from: data)
+        return bills.sorted {
+            if let l1 = $0.lastchanged, let l2 = $1.lastchanged {
+                return l1 > l2
+            }
+            return $0.date > $1.date
+        }
+    }
+    
+    func loadMembers(_ project: Project) async throws -> [Int: Person] {
+        let request = buildURLRequest("members", params: [:], project: project)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+        
+        guard httpResponse.statusCode == 200 else {
+            throw NetworkError.statusCode(httpResponse.statusCode)
+        }
+        
+        let membersArray = try decoder.decode([Person].self, from: data)
+        return Dictionary(uniqueKeysWithValues: membersArray.map { ($0.id, $0) })
+    }
+    
+    func uploadBill(_ bill: Bill, to project: Project) async throws -> Int? {
+        let isUpdate = bill.id > 0 // Positive IDs are updates, negative are new
+        let endpoint = isUpdate ? "bills/\(bill.id)" : "bills"
+        let httpMethod = isUpdate ? "PUT" : "POST"
+        
+        let request = buildURLRequest(endpoint, params: bill.paramsFor(project.backend), project: project, httpMethod: httpMethod)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+        
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 201 else {
+            throw NetworkError.statusCode(httpResponse.statusCode)
+        }
+        
+        // For new bills (POST), try to extract the server-assigned ID
+        if !isUpdate && httpResponse.statusCode == 201 {
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let serverId = json["id"] as? Int {
+                    return serverId
+                }
+            } catch {
+                print("Could not parse server response for new bill ID: \(error)")
+            }
+        }
+        
+        return nil
+    }
+    
+    func uploadMember(_ member: Person, to project: Project) async throws -> Int? {
+        let isUpdate = member.id > 0 // Positive IDs are updates, negative are new
+        let endpoint = isUpdate ? "members/\(member.id)" : "members"
+        let httpMethod = isUpdate ? "PUT" : "POST"
+        
+        var params: [String: Any] = [
+            "name": member.name,
+            "weight": member.weight
+        ]
+        if isUpdate {
+            params["id"] = member.id
+        }
+        
+        let request = buildURLRequest(endpoint, params: params, project: project, httpMethod: httpMethod)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+        
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 201 else {
+            throw NetworkError.statusCode(httpResponse.statusCode)
+        }
+        
+        // For new members (POST), try to extract the server-assigned ID
+        if !isUpdate && httpResponse.statusCode == 201 {
+            do {
+                if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let serverId = json["id"] as? Int {
+                    return serverId
+                }
+            } catch {
+                print("Could not parse server response for new member ID: \(error)")
+            }
+        }
+        
+        return nil
+    }
+    
+    func deleteBill(_ billId: Int, from project: Project) async throws {
+        let endpoint = "bills/\(billId)"
+        let request = buildURLRequest(endpoint, params: [:], project: project, httpMethod: "DELETE")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+        
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 204 else {
+            throw NetworkError.statusCode(httpResponse.statusCode)
+        }
+    }
+    
+    func deleteMember(_ memberId: Int, from project: Project) async throws {
+        let endpoint = "members/\(memberId)"
+        let request = buildURLRequest(endpoint, params: [:], project: project, httpMethod: "DELETE")
+        let (_, response) = try await URLSession.shared.data(for: request)
+        
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NetworkError.noResponse
+        }
+        
+        guard httpResponse.statusCode == 200 || httpResponse.statusCode == 204 else {
+            throw NetworkError.statusCode(httpResponse.statusCode)
+        }
+    }
 
     enum HTTPError: LocalizedError {
         case statuscode
+    }
+    
+    enum NetworkError: Error {
+        case noResponse
+        case statusCode(Int)
+        case decodingError
     }
 
     enum ServerError: LocalizedError {

--- a/PayForMe/Services/ProjectManager.swift
+++ b/PayForMe/Services/ProjectManager.swift
@@ -7,8 +7,47 @@
 
 import Combine
 import Foundation
+import UIKit
 
 class ProjectManager: ObservableObject {
+    // Expose for testing
+    func performMergeBillsTest(local: [Bill], oldServer: [Bill], freshServer: [Bill]) -> [Bill] {
+        return mergeBills(local: local, oldServer: oldServer, freshServer: freshServer)
+    }
+
+    /// Merge local unsynced bills (with negative IDs) with truly new server bills, matching by content to avoid duplicates and preserve unsynced bills
+    /// - Parameters:
+    ///   - local: All local bills (including unsynced)
+    ///   - oldServer: Bills that existed on the server before sync
+    ///   - freshServer: Bills just downloaded from the server after sync
+    /// - Returns: The merged list of bills
+    private func mergeBills(local: [Bill], oldServer: [Bill], freshServer: [Bill]) -> [Bill] {
+        // Only consider local bills with negative IDs (not yet on server)
+        let localUnsynced = local.filter { $0.id < 0 }
+
+        // Find truly new server bills (those in freshServer but not in oldServer, by id)
+        let oldServerIDs = Set(oldServer.map { $0.id })
+        let newServerBills = freshServer.filter { !oldServerIDs.contains($0.id) }
+
+        // Start with all fresh server bills
+        var merged = freshServer
+        for localBill in localUnsynced {
+            let exists = newServerBills.contains { serverBill in
+                let amountMatch = abs(serverBill.amount - localBill.amount) < 0.01
+                let whatMatch = serverBill.what == localBill.what
+                let payerMatch = serverBill.payer_id == localBill.payer_id
+                let owersMatch = Set(serverBill.owers.map { $0.id }) == Set(localBill.owers.map { $0.id })
+                let repeatMatch = serverBill.repeat == localBill.repeat
+                // Add more fields if needed
+                let match = amountMatch && whatMatch && payerMatch && owersMatch && repeatMatch
+                return match
+            }
+            if !exists {
+                merged.append(localBill)
+            }
+        }
+        return merged
+    }
     private let defaults = UserDefaults.standard
 
     private var cancellable: Cancellable?
@@ -24,6 +63,17 @@ class ProjectManager: ObservableObject {
     static let shared = ProjectManager()
 
     @Published var openedByURL: URL?
+    
+    // Offline status tracking
+    @Published var isOffline: Bool = false
+    @Published var lastSyncDate: Date?
+    private var networkMonitorCancellable: AnyCancellable?
+    
+    // Local changes tracking
+    @Published var localBillsToUpload: Set<Int> = []
+    @Published var localMembersToUpload: Set<Int> = []
+    @Published var localBillsToDelete: Set<Int> = []
+    @Published var localMembersToDelete: Set<Int> = []
 
     private init() {
         print("init")
@@ -34,12 +84,24 @@ class ProjectManager: ObservableObject {
             $0.id == id
         }) {
             currentProject = project
+            // Load last sync date from cache
+            lastSyncDate = defaults.object(forKey: "lastSyncDate_\(project.id ?? 0)") as? Date
+            // Start as potentially offline until we confirm connection
+            isOffline = true
+            // Load cached data first to ensure bills are always visible
+            loadCachedData()
             loadBillsAndMembers()
         } else {
             if !projects.isEmpty {
                 currentProject = projects[0]
+                isOffline = true
+                // Load cached data first to ensure bills are always visible
+                loadCachedData()
             }
         }
+        
+        // Set up automatic retry when app becomes active
+        setupNetworkMonitoring()
     }
 
     func openedByURL(url: URL) {
@@ -55,19 +117,270 @@ class ProjectManager: ObservableObject {
     // MARK: Server Communication
 
     func loadBillsAndMembers() {
+        _ = currentProject
+        
+        // Always load cached data first - makes app work transparently
+        loadCachedData()
+        
+        // Try to sync in background without blocking UI
+        Task {
+            await syncData()
+        }
+    }
+    
+    func loadBillsAndMembersLegacy() {
         let project = currentProject
+        
+        // Load cached data first
+        loadCachedData()
 
-        let billsPublisher = NetworkService.shared.loadBillsPublisher(project)
-        let membersPublisher = NetworkService.shared.loadMembersPublisher(project)
+        _ = NetworkService.shared.loadBillsPublisher(project)
+        _ = NetworkService.shared.loadMembersPublisher(project)
 
-        Publishers.Zip(billsPublisher, membersPublisher)
-            .map { bills, members in
-                project.bills = bills
-                project.members = members
-                return project
+        Publishers.Zip(
+            NetworkService.shared.loadBillsWithStatusPublisher(project),
+            NetworkService.shared.loadMembersWithStatusPublisher(project)
+        )
+        .map { billsResult, membersResult in
+            var networkSuccess = false
+            
+            // Handle bills result
+            switch billsResult {
+            case .success(let fetchedBills):
+                project.bills = fetchedBills
+                networkSuccess = true
+            case .failure:
+                // Keep existing bills from cache (already loaded)
+                break
             }
+            
+            // Handle members result
+            switch membersResult {
+            case .success(let fetchedMembers):
+                project.members = fetchedMembers
+                networkSuccess = true
+            case .failure:
+                // Keep existing members from cache (already loaded)
+                break
+            }
+            
+            // Update offline status
+            if networkSuccess {
+                self.isOffline = false
+                self.lastSyncDate = Date()
+                
+                // Cache the fresh data
+                self.cacheProjectData(project: project, bills: project.bills, members: project.members)
+            } else {
+                self.isOffline = true
+            }
+            
+            return project
+        }
             .receive(on: DispatchQueue.main)
             .assign(to: &$currentProject)
+    }
+    
+    @MainActor
+    func syncData() async {
+        let project = currentProject
+        
+        // Load cached data first to ensure bills are always visible
+        loadCachedData()
+        
+        do {
+            // Upload any local changes first
+            await uploadLocalChanges(project: project)
+
+            // Then download fresh data from server
+            async let billsTask = NetworkService.shared.loadBills(project)
+            async let membersTask = NetworkService.shared.loadMembers(project)
+
+            let freshBills = try await billsTask
+            let freshMembers = try await membersTask
+
+            // Merge local unsynced bills with only the truly new server bills
+            let mergedBills = mergeBills(local: project.bills, oldServer: project.bills.filter { $0.id > 0 }, freshServer: freshBills)
+
+            // Update the current project with merged data
+            currentProject.bills = mergedBills
+            currentProject.members = freshMembers
+
+            // Cache the fresh data (cache merged bills)
+            cacheProjectData(project: currentProject, bills: mergedBills, members: freshMembers)
+
+            // Update sync status
+            isOffline = false
+            lastSyncDate = Date()
+            defaults.set(lastSyncDate, forKey: "lastSyncDate_\(currentProject.id ?? 0)")
+
+        } catch {
+            print("Sync failed, staying offline: \(error)")
+            isOffline = true
+        }
+    }
+    
+    private func uploadLocalChanges(project: Project) async {
+        // Upload any bills that were created/modified locally
+        let billsToUpload = Array(localBillsToUpload)
+        var didUploadBill = false
+        for billId in billsToUpload {
+            if let billIndex = project.bills.firstIndex(where: { $0.id == billId }) {
+                let bill = project.bills[billIndex]
+                do {
+                    // Try to upload the bill
+                    if let newServerId = try await NetworkService.shared.uploadBill(bill, to: project) {
+                        // For new bills with negative IDs, replace with server-assigned ID and remove the negative-ID bill
+                        await MainActor.run {
+                            var updatedBill = bill
+                            updatedBill.id = newServerId
+                            // Remove the negative-ID bill
+                            currentProject.bills.removeAll(where: { $0.id == billId })
+                            // Add the updated bill with the new server ID
+                            currentProject.bills.append(updatedBill)
+                            localBillsToUpload.remove(billId) // Remove old negative ID
+                        }
+                        didUploadBill = true
+                    } else {
+                        // Remove from local changes set if successful (update case)
+                        await MainActor.run {
+                            localBillsToUpload.remove(billId)
+                        }
+                    }
+                } catch {
+                    print("Failed to upload bill \(billId): \(error)")
+                    // Keep in local changes set for next sync attempt
+                }
+            }
+        }
+        
+        // Delete any bills that were deleted locally
+        let billsToDelete = Array(localBillsToDelete)
+        for billId in billsToDelete {
+            do {
+                // Try to delete the bill from server (only if it has positive ID)
+                if billId > 0 {
+                    try await NetworkService.shared.deleteBill(billId, from: project)
+                }
+                // Remove from local deletions set if successful
+                await MainActor.run {
+                    localBillsToDelete.remove(billId)
+                }
+            } catch {
+                print("Failed to delete bill \(billId): \(error)")
+                // Keep in local deletions set for next sync attempt
+            }
+        }
+        
+        // Upload any members that were created/updated locally
+        let membersToUpload = Array(localMembersToUpload)
+        for memberId in membersToUpload {
+            if let member = project.members[memberId] {
+                do {
+                    // Try to upload the member
+                    if let newServerId = try await NetworkService.shared.uploadMember(member, to: project) {
+                        // For new members with negative IDs, update to server-assigned ID
+                        await MainActor.run {
+                            var updatedMember = member
+                            updatedMember.id = newServerId
+                            currentProject.members.removeValue(forKey: memberId) // Remove old negative ID
+                            currentProject.members[newServerId] = updatedMember // Add with new positive ID
+                            localMembersToUpload.remove(memberId) // Remove old negative ID
+                            
+                            // Update any bills that reference this member
+                            updateBillMemberReferences(oldMemberId: memberId, newMemberId: newServerId, updatedMember: updatedMember)
+                        }
+                    } else {
+                        // Remove from local changes set if successful (update case)
+                        await MainActor.run {
+                            localMembersToUpload.remove(memberId)
+                        }
+                    }
+                } catch {
+                    print("Failed to upload member \(memberId): \(error)")
+                    // Keep in local changes set for next sync attempt
+                }
+            }
+        }
+        
+        // Delete any members that were deleted locally
+        let membersToDelete = Array(localMembersToDelete)
+        for memberId in membersToDelete {
+            do {
+                // Try to delete the member from server (only if it has positive ID)
+                if memberId > 0 {
+                    try await NetworkService.shared.deleteMember(memberId, from: project)
+                }
+                // Remove from local deletions set if successful
+                await MainActor.run {
+                    localMembersToDelete.remove(memberId)
+                }
+            } catch {
+                print("Failed to delete member \(memberId): \(error)")
+                // Keep in local deletions set for next sync attempt
+            }
+        }
+        // After all uploads/deletions, if any bills were uploaded, trigger a sync to fetch the latest server data
+        if didUploadBill {
+            await MainActor.run {
+                Task {
+                    await self.syncData()
+                }
+            }
+        }
+    }
+    
+    private func loadCachedData() {
+        if let cachedData = loadCachedProjectData() {
+            currentProject.bills = cachedData.bills
+            currentProject.members = cachedData.members
+            // Restore local change queues
+            localBillsToUpload = cachedData.localBillsToUpload
+            localMembersToUpload = cachedData.localMembersToUpload
+            localBillsToDelete = cachedData.localBillsToDelete
+            localMembersToDelete = cachedData.localMembersToDelete
+        }
+    }
+    
+    private func cacheProjectData(project: Project, bills: [Bill], members: [Int: Person]) {
+        let cacheData = CachedProjectData(
+            bills: bills,
+            members: members,
+            cachedAt: Date(),
+            localBillsToUpload: localBillsToUpload,
+            localMembersToUpload: localMembersToUpload,
+            localBillsToDelete: localBillsToDelete,
+            localMembersToDelete: localMembersToDelete
+        )
+        let cacheKey = "cached_project_\(project.id ?? 0)"
+        
+        if let encoded = try? JSONEncoder().encode(cacheData) {
+            defaults.set(encoded, forKey: cacheKey)
+        }
+    }
+    
+    private func loadCachedProjectData() -> CachedProjectData? {
+        let cacheKey = "cached_project_\(currentProject.id ?? 0)"
+        
+        guard let data = defaults.data(forKey: cacheKey) else {
+            return nil
+        }
+        
+        // First try to decode new format
+        if let cachedData = try? JSONDecoder().decode(CachedProjectData.self, from: data) {
+            return cachedData
+        }
+        
+        // Fall back to old format for backward compatibility
+        if let oldCachedData = try? JSONDecoder().decode(OldCachedProjectData.self, from: data) {
+            return CachedProjectData(
+                bills: oldCachedData.bills,
+                members: oldCachedData.members,
+                cachedAt: oldCachedData.cachedAt
+            )
+        }
+        
+        return nil
     }
 
     private func sendBillToServer(bill: Bill, update: Bool, completion: @escaping () -> Void) {
@@ -200,33 +513,212 @@ extension ProjectManager {
     }
 
     func saveBill(_ bill: Bill, completion: @escaping () -> Void) {
-        if bill.id != -1, let _ = currentProject.bills.firstIndex(where: {
-            $0.id == bill.id
-        }) {
-            sendBillToServer(bill: bill, update: true, completion: completion)
+        var billToSave = bill
+        let isUpdate = bill.id != -1 && currentProject.bills.contains(where: { $0.id == bill.id })
+
+        // Update local data immediately for transparent offline experience
+        if isUpdate {
+            if let index = currentProject.bills.firstIndex(where: { $0.id == bill.id }) {
+                currentProject.bills[index] = billToSave
+            }
         } else {
-            sendBillToServer(bill: bill, update: false, completion: completion)
+            // Assign temporary negative ID for new bills
+            if billToSave.id == -1 {
+                billToSave.id = -Int.random(in: 1000...999999) // Temporary negative ID
+            }
+            currentProject.bills.append(billToSave)
         }
+
+        // Cache the updated data
+        cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+
+        // Track for upload when online
+        localBillsToUpload.insert(billToSave.id)
+
+        // Try to upload immediately if online, but don't block the UI
+        Task {
+            if !isOffline {
+                do {
+                    if let newServerId = try await NetworkService.shared.uploadBill(billToSave, to: currentProject) {
+                        // For new bills with negative IDs, update to server-assigned ID
+                        await MainActor.run {
+                            // Remove the negative-ID bill if present
+                            currentProject.bills.removeAll(where: { $0.id == billToSave.id })
+                            localBillsToUpload.remove(billToSave.id)
+                            // Add the updated bill with the new server ID
+                            var updatedBill = billToSave
+                            updatedBill.id = newServerId
+                            currentProject.bills.append(updatedBill)
+                            // Cache the updated data
+                            cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+                        }
+                    } else {
+                        // Remove from pending uploads if successful (update case)
+                        await MainActor.run {
+                            localBillsToUpload.remove(billToSave.id)
+                        }
+                    }
+                } catch {
+                    print("Failed to upload bill immediately: \(error)")
+                    // Will be retried during next sync
+                }
+            }
+        }
+
+        // Always call completion immediately for responsive UI
+        completion()
     }
 
     func deleteBill(_ bill: Bill, completion: @escaping () -> Void) {
+        // Remove from local data immediately for transparent offline experience
         currentProject.bills.removeAll {
             $0.id == bill.id
         }
-        deleteBillFromServer(bill: bill, completion: completion)
+        
+        // Cache the updated data
+        cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+        
+        // Track for deletion when online (only if it has a positive ID, meaning it exists on server)
+        if bill.id > 0 {
+            localBillsToDelete.insert(bill.id)
+            // Remove from upload queue if it was there
+            localBillsToUpload.remove(bill.id)
+        }
+        
+        // Try to delete immediately if online, but don't block the UI
+        Task {
+            if !isOffline && bill.id > 0 {
+                do {
+                    try await NetworkService.shared.deleteBill(bill.id, from: currentProject)
+                    // Remove from pending deletions if successful
+                    await MainActor.run {
+                        localBillsToDelete.remove(bill.id)
+                    }
+                } catch {
+                    print("Failed to delete bill immediately: \(error)")
+                    // Will be retried during next sync
+                }
+            }
+        }
+        
+        // Always call completion immediately for responsive UI
+        completion()
     }
 
     func addMember(_ name: String, completion: @escaping () -> Void) {
-        let newMember = Person(id: -1, weight: -1, name: name, activated: true, color: nil)
-        sendMemberToServer(newMember, update: false, completion: completion)
+        // Create member with temporary negative ID
+        let tempId = -Int.random(in: 1000...999999)
+        let newMember = Person(id: tempId, weight: 1, name: name, activated: true, color: nil)
+        
+        // Add to local data immediately for transparent offline experience
+        currentProject.members[tempId] = newMember
+        
+        // Cache the updated data
+        cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+        
+        // Track for upload when online
+        localMembersToUpload.insert(tempId)
+        
+        // Try to upload immediately if online, but don't block the UI
+        Task {
+            if !isOffline {
+                do {
+                    if let newServerId = try await NetworkService.shared.uploadMember(newMember, to: currentProject) {
+                        // For new members with negative IDs, update to server-assigned ID
+                        await MainActor.run {
+                            var updatedMember = newMember
+                            updatedMember.id = newServerId
+                            currentProject.members.removeValue(forKey: tempId) // Remove old negative ID
+                            currentProject.members[newServerId] = updatedMember // Add with new positive ID
+                            localMembersToUpload.remove(tempId) // Remove old negative ID
+                            
+                            // Update any bills that reference this member
+                            updateBillMemberReferences(oldMemberId: tempId, newMemberId: newServerId, updatedMember: updatedMember)
+                            
+                            // Cache the updated data
+                            cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+                        }
+                    } else {
+                        // Remove from pending uploads if successful (update case)
+                        await MainActor.run {
+                            localMembersToUpload.remove(tempId)
+                        }
+                    }
+                } catch {
+                    print("Failed to upload member immediately: \(error)")
+                    // Will be retried during next sync
+                }
+            }
+        }
+        
+        // Always call completion immediately for responsive UI
+        completion()
     }
 
     func updateMember(_ member: Person, completion: @escaping () -> Void) {
-        sendMemberToServer(member, update: true, completion: completion)
+        // Update local data immediately for transparent offline experience
+        currentProject.members[member.id] = member
+        
+        // Cache the updated data
+        cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+        
+        // Track for upload when online (only if it has a positive ID, meaning it exists on server)
+        if member.id > 0 {
+            localMembersToUpload.insert(member.id)
+        }
+        
+        // Try to upload immediately if online, but don't block the UI
+        Task {
+            if !isOffline && member.id > 0 {
+                do {
+                    let _ = try await NetworkService.shared.uploadMember(member, to: currentProject)
+                    // Remove from pending uploads if successful (this is always an update case)
+                    await MainActor.run {
+                        localMembersToUpload.remove(member.id)
+                    }
+                } catch {
+                    print("Failed to upload member immediately: \(error)")
+                    // Will be retried during next sync
+                }
+            }
+        }
+        
+        // Always call completion immediately for responsive UI
+        completion()
     }
 
     func deleteMember(_ member: Person, completion: @escaping () -> Void) {
-        deleteMemberFromServer(member, completion: completion)
+        // Remove from local data immediately for transparent offline experience
+        currentProject.members.removeValue(forKey: member.id)
+        
+        // Cache the updated data
+        cacheProjectData(project: currentProject, bills: currentProject.bills, members: currentProject.members)
+        
+        // Track for deletion when online (only if it has a positive ID, meaning it exists on server)
+        if member.id > 0 {
+            localMembersToDelete.insert(member.id)
+            // Remove from upload queue if it was there
+            localMembersToUpload.remove(member.id)
+        }
+        
+        // Try to delete immediately if online, but don't block the UI
+        Task {
+            if !isOffline && member.id > 0 {
+                do {
+                    try await NetworkService.shared.deleteMember(member.id, from: currentProject)
+                    // Remove from pending deletions if successful
+                    await MainActor.run {
+                        localMembersToDelete.remove(member.id)
+                    }
+                } catch {
+                    print("Failed to delete member immediately: \(error)")
+                    // Will be retried during next sync
+                }
+            }
+        }
+        
+        // Always call completion immediately for responsive UI
+        completion()
     }
 
     func setCurrentProject(_ project: Project) {
@@ -236,6 +728,16 @@ extension ProjectManager {
             return
         }
         currentProject = project
+        
+        // Clear previous project's local change queues
+        localBillsToUpload.removeAll()
+        localMembersToUpload.removeAll()
+        localBillsToDelete.removeAll()
+        localMembersToDelete.removeAll()
+        
+        // Load last sync date from cache
+        lastSyncDate = defaults.object(forKey: "lastSyncDate_\(project.id ?? 0)") as? Date
+        
         loadBillsAndMembers()
         defaults.set(project.id, forKey: "projectID")
     }
@@ -243,4 +745,85 @@ extension ProjectManager {
     func updateProject(project: Project) {
         storageService.updateProject(project: project)
     }
+    
+    // MARK: - Network Monitoring
+    
+    private func setupNetworkMonitoring() {
+        // Monitor app lifecycle to retry when app becomes active
+        networkMonitorCancellable = NotificationCenter.default
+            .publisher(for: UIApplication.didBecomeActiveNotification)
+            .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
+            .sink { _ in
+                if self.isOffline {
+                    self.retryConnection()
+                }
+            }
+    }
+    
+    func retryConnection() {
+        loadBillsAndMembers()
+    }
+    
+    // MARK: - Helper Methods
+    
+    private func updateBillMemberReferences(oldMemberId: Int, newMemberId: Int, updatedMember: Person) {
+        // Update bills that reference this member as payer or ower
+        for i in 0..<currentProject.bills.count {
+            var bill = currentProject.bills[i]
+            var needsUpdate = false
+            
+            // Update payer_id if it matches the old member ID
+            if bill.payer_id == oldMemberId {
+                bill.payer_id = newMemberId
+                needsUpdate = true
+            }
+            
+            // Update owers array if it contains the old member
+            for j in 0..<bill.owers.count {
+                if bill.owers[j].id == oldMemberId {
+                    bill.owers[j] = updatedMember
+                    needsUpdate = true
+                }
+            }
+            
+            if needsUpdate {
+                currentProject.bills[i] = bill
+                // Mark this bill for upload if it's not already queued
+                if bill.id > 0 {
+                    localBillsToUpload.insert(bill.id)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Cached Data Structure
+
+struct CachedProjectData: Codable {
+    let bills: [Bill]
+    let members: [Int: Person]
+    let cachedAt: Date
+    let localBillsToUpload: Set<Int>
+    let localMembersToUpload: Set<Int>
+    let localBillsToDelete: Set<Int>
+    let localMembersToDelete: Set<Int>
+    
+    init(bills: [Bill], members: [Int: Person], cachedAt: Date,
+         localBillsToUpload: Set<Int> = [], localMembersToUpload: Set<Int> = [],
+         localBillsToDelete: Set<Int> = [], localMembersToDelete: Set<Int> = []) {
+        self.bills = bills
+        self.members = members
+        self.cachedAt = cachedAt
+        self.localBillsToUpload = localBillsToUpload
+        self.localMembersToUpload = localMembersToUpload
+        self.localBillsToDelete = localBillsToDelete
+        self.localMembersToDelete = localMembersToDelete
+    }
+}
+
+// For backward compatibility with old cached data
+struct OldCachedProjectData: Codable {
+    let bills: [Bill]
+    let members: [Int: Person]
+    let cachedAt: Date
 }

--- a/PayForMe/Util/Util.swift
+++ b/PayForMe/Util/Util.swift
@@ -217,7 +217,7 @@ extension URL {
 }
 
 // Why is URL an identifier but not identifiable?
-extension URL: Identifiable {
+extension URL: @retroactive Identifiable {
     public var id: URL {
         self
     }

--- a/PayForMe/Views/Balance/BalanceList.swift
+++ b/PayForMe/Views/Balance/BalanceList.swift
@@ -29,7 +29,9 @@ struct BalanceList: View {
 
     @ViewBuilder
     var mainView: some View {
-        VStack(alignment: .center) {
+        VStack(alignment: .center, spacing: 0) {
+            OfflineStatusView()
+            
             if addingUser {
                 AddMemberView(memberName: $memberName, addMemberAction: submitUser, cancelButtonAction: cancelAddUser)
             }
@@ -51,6 +53,9 @@ struct BalanceList: View {
                     BalanceCell(balance: balance)
                 }
             }
+        }
+        .refreshable {
+            await ProjectManager.shared.syncData()
         }
     }
 

--- a/PayForMe/Views/BillList/BillList.swift
+++ b/PayForMe/Views/BillList/BillList.swift
@@ -16,11 +16,18 @@ struct BillList: View {
 
     var body: some View {
         NavigationView {
-            List {
-                iOS15ListContent
+            VStack(spacing: 0) {
+                OfflineStatusView()
+                
+                List {
+                    iOS15ListContent
+                }
+                .refreshable {
+                    await ProjectManager.shared.syncData()
+                }
+                .addFloatingAddButton()
+                .id(viewModel.currentProject.bills)
             }
-            .addFloatingAddButton()
-            .id(viewModel.currentProject.bills)
             .navigationBarTitle("Bills")
             .alert(item: $deleteAlert) { index in
                 Alert(title: Text("Delete Bill"),
@@ -71,7 +78,7 @@ struct BillList: View {
     }
 }
 
-extension IndexSet: Identifiable {
+extension IndexSet: @retroactive Identifiable {
     public var id: Int {
         hashValue
     }

--- a/PayForMe/Views/BillList/BillListViewModel.swift
+++ b/PayForMe/Views/BillList/BillListViewModel.swift
@@ -10,7 +10,7 @@ import Foundation
 
 class BillListViewModel: ObservableObject {
     var manager = ProjectManager.shared
-    var cancellable: Cancellable?
+    var cancellable: AnyCancellable?
 
     @Published
     var currentProject: Project
@@ -26,18 +26,20 @@ class BillListViewModel: ObservableObject {
 
     init() {
         currentProject = manager.currentProject
-        cancellable = currentProjectChanged
+        cancellable = manager.$currentProject.sink { [weak self] newProject in
+            guard let self = self else { return }
+            self.currentProject = newProject
+            self.sortedBills = self.sortBy.sort(bills: newProject.bills)
+        }
         $sortBy
-            .map {
-                $0.sort(bills: self.currentProject.bills)
+            .sink { [weak self] sortBy in
+                guard let self = self else { return }
+                self.sortedBills = sortBy.sort(bills: self.currentProject.bills)
             }
-            .assign(to: &$sortedBills)
+            .store(in: &cancellables)
     }
 
-    var currentProjectChanged: AnyCancellable {
-        manager.$currentProject
-            .assign(to: \.currentProject, on: self)
-    }
+    private var cancellables = Set<AnyCancellable>()
 
     enum SortedBy: String {
         case expenseDate
@@ -51,7 +53,7 @@ class BillListViewModel: ObservableObject {
                 }
             case .changedDate:
                 return bills.sorted { a, b in
-                    a.lastchanged ?? 0 > b.lastchanged ?? 0
+                    (a.lastchanged ?? 0) > (b.lastchanged ?? 0)
                 }
             }
         }

--- a/PayForMe/Views/OfflineStatusView.swift
+++ b/PayForMe/Views/OfflineStatusView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+struct OfflineStatusView: View {
+    @ObservedObject var manager = ProjectManager.shared
+    @State private var isRetrying = false
+    
+    var body: some View {
+        if manager.isOffline || isRetrying || (!manager.localBillsToUpload.isEmpty || !manager.localMembersToUpload.isEmpty) {
+            HStack {
+                if isRetrying {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                    Text("Syncing...")
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                } else if manager.isOffline {
+                    Image(systemName: "wifi.slash")
+                        .foregroundColor(.orange)
+                    Text("Offline - showing cached data")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                } else if !manager.localBillsToUpload.isEmpty || !manager.localMembersToUpload.isEmpty || !manager.localBillsToDelete.isEmpty || !manager.localMembersToDelete.isEmpty {
+                    Image(systemName: "icloud.and.arrow.up")
+                        .foregroundColor(.blue)
+                    Text("Changes pending upload")
+                        .font(.caption)
+                        .foregroundColor(.blue)
+                }
+                
+                if let lastSync = manager.lastSyncDate, !isRetrying {
+                    Text("Last sync: \(formatDate(lastSync))")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                if !isRetrying {
+                    Button("Retry") {
+                        withAnimation {
+                            isRetrying = true
+                        }
+                        manager.retryConnection()
+                    }
+                    .font(.caption)
+                    .foregroundColor(.blue)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+            .background(isRetrying ? Color.blue.opacity(0.1) : Color.orange.opacity(0.1))
+            .onReceive(manager.$isOffline) { offline in
+                if !offline && isRetrying {
+                    withAnimation {
+                        isRetrying = false
+                    }
+                }
+            }
+        }
+    }
+    
+    private func formatDate(_ date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+struct OfflineStatusView_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack {
+            OfflineStatusView()
+            Spacer()
+        }
+    }
+}

--- a/PayForMeTests/BillMergeTests.swift
+++ b/PayForMeTests/BillMergeTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import PayForMe
+
+public class BillMergeTests: XCTestCase {
+    public func testMergeBills_DuplicateDetection() {
+        let now = Date()
+        let person1 = Person(id: 1, weight: 1, name: "A", activated: true)
+        let person2 = Person(id: 2, weight: 1, name: "B", activated: true)
+        let owers1 = [person1, person2]
+        let owers2 = [person2, person1] // different order
+        let localBill = Bill(id: -1, amount: 10.0, what: "Lunch", date: now, payer_id: 1, owers: owers1, repeat: nil, lastchanged: nil)
+        let serverBill = Bill(id: 100, amount: 10.0, what: "Lunch", date: now, payer_id: 1, owers: owers2, repeat: nil, lastchanged: nil)
+        let pm = ProjectManager.shared
+        let merged = pm.performMergeBillsTest(local: [localBill], server: [serverBill])
+        // Only the server bill should remain
+        XCTAssertEqual(merged.count, 1)
+        XCTAssertEqual(merged[0].id, 100)
+    }
+    public func testMergeBills_DifferentAmount() {
+        let now = Date()
+        let person1 = Person(id: 1, weight: 1, name: "A", activated: true)
+        let person2 = Person(id: 2, weight: 1, name: "B", activated: true)
+        let owers = [person1, person2]
+        let localBill = Bill(id: -1, amount: 10.0, what: "Lunch", date: now, payer_id: 1, owers: owers, repeat: nil, lastchanged: nil)
+        let serverBill = Bill(id: 100, amount: 11.0, what: "Lunch", date: now, payer_id: 1, owers: owers, repeat: nil, lastchanged: nil)
+        let pm = ProjectManager.shared
+        let merged = pm.performMergeBillsTest(local: [localBill], server: [serverBill])
+        // Both bills should remain
+        XCTAssertEqual(merged.count, 2)
+    }
+}


### PR DESCRIPTION
I'm trying to solve a problem where bills and members appear empty from time to time.

I want to keep an offline copy and sync it when it is possible, but I cannot run the application on any iOS device because I don't own a Mac.

I am unable to test the PR, so if it is useful to you, please use it; if not, you can feel free to close it.