### PR TITLE
re-addressing "429: too many requests"

### DIFF
--- a/PayForMe/Model/Project.swift
+++ b/PayForMe/Model/Project.swift
@@ -94,9 +94,9 @@ enum ProjectBackend: Int, Codable {
     var staticPath: String {
         switch self {
         case .cospend:
-            return "/index.php/apps/cospend/api/projects"
+            return "index.php/apps/cospend/api/projects"
         case .iHateMoney:
-            return "/api/projects"
+            return "api/projects"
         }
     }
 }

--- a/PayForMe/Services/ProjectManager.swift
+++ b/PayForMe/Services/ProjectManager.swift
@@ -88,6 +88,7 @@ class ProjectManager: ObservableObject {
 
         if update {
             cancellable = NetworkService.shared.updateBillPublisher(bill: bill)
+                .receive(on: DispatchQueue.main)
                 .sink { success in
                     if success {
                         print("Bill id\(bill.id) updated")
@@ -98,6 +99,7 @@ class ProjectManager: ObservableObject {
                 }
         } else {
             cancellable = NetworkService.shared.postBillPublisher(bill: bill)
+                .receive(on: DispatchQueue.main)
                 .sink { success in
                     if success {
                         print("Bill posted")
@@ -114,6 +116,7 @@ class ProjectManager: ObservableObject {
         cancellable = nil
 
         cancellable = NetworkService.shared.deleteBillPublisher(bill: bill)
+            .receive(on: DispatchQueue.main)
             .sink { success in
                 if success {
                     print("Bill successfully deleted")
@@ -130,6 +133,7 @@ class ProjectManager: ObservableObject {
 
         if update {
             cancellable = NetworkService.shared.updateMemberPublisher(member: member)
+                .receive(on: DispatchQueue.main)
                 .sink { success in
                     if success {
                         print("Member id\(member.id) updated")
@@ -140,6 +144,7 @@ class ProjectManager: ObservableObject {
                 }
         } else {
             cancellable = NetworkService.shared.createMemberPublisher(name: member.name)
+                .receive(on: DispatchQueue.main)
                 .sink { success in
                     if success {
                         print("Member successfully created")
@@ -156,6 +161,7 @@ class ProjectManager: ObservableObject {
         cancellable = nil
 
         cancellable = NetworkService.shared.deleteMemberPublisher(member: member)
+            .receive(on: DispatchQueue.main)
             .sink { success in
                 if success {
                     print("Member id\(member.id) successfully deleted")

--- a/PayForMe/Services/ProjectManager.swift
+++ b/PayForMe/Services/ProjectManager.swift
@@ -55,7 +55,15 @@ class ProjectManager: ObservableObject {
 
     // MARK: Server Communication
 
-    func loadBillsAndMembers() {
+    func refresh() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            loadBillsAndMembers {
+                continuation.resume()
+            }
+        }
+    }
+
+    func loadBillsAndMembers(completion: (() -> Void)? = nil) {
         let project = currentProject
 
         let billsPublisher = NetworkService.shared.loadBillsPublisher(project)
@@ -70,6 +78,7 @@ class ProjectManager: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] project in
                 self?.currentProject = project
+                completion?()
             }
     }
 

--- a/PayForMe/Services/ProjectManager.swift
+++ b/PayForMe/Services/ProjectManager.swift
@@ -69,6 +69,13 @@ class ProjectManager: ObservableObject {
         let billsPublisher = NetworkService.shared.loadBillsPublisher(project)
         let membersPublisher = NetworkService.shared.loadMembersPublisher(project)
 
+        var completionInvoked = false
+        let invokeCompletionOnce: () -> Void = {
+            guard !completionInvoked else { return }
+            completionInvoked = true
+            completion?()
+        }
+
         loadCancellable = Publishers.Zip(billsPublisher, membersPublisher)
             .map { bills, members in
                 project.bills = bills
@@ -76,10 +83,14 @@ class ProjectManager: ObservableObject {
                 return project
             }
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] project in
-                self?.currentProject = project
-                completion?()
-            }
+            .handleEvents(receiveCancel: invokeCompletionOnce)
+            .sink(
+                receiveCompletion: { _ in invokeCompletionOnce() },
+                receiveValue: { [weak self] project in
+                    self?.currentProject = project
+                    invokeCompletionOnce()
+                }
+            )
     }
 
     private func sendBillToServer(bill: Bill, update: Bool, completion: @escaping () -> Void) {

--- a/PayForMe/Services/ProjectManager.swift
+++ b/PayForMe/Services/ProjectManager.swift
@@ -12,6 +12,7 @@ class ProjectManager: ObservableObject {
     private let defaults = UserDefaults.standard
 
     private var cancellable: Cancellable?
+    private var loadCancellable: AnyCancellable?
 
     @Published
     private(set) var projects = [Project]()
@@ -60,14 +61,16 @@ class ProjectManager: ObservableObject {
         let billsPublisher = NetworkService.shared.loadBillsPublisher(project)
         let membersPublisher = NetworkService.shared.loadMembersPublisher(project)
 
-        Publishers.Zip(billsPublisher, membersPublisher)
+        loadCancellable = Publishers.Zip(billsPublisher, membersPublisher)
             .map { bills, members in
                 project.bills = bills
                 project.members = members
                 return project
             }
             .receive(on: DispatchQueue.main)
-            .assign(to: &$currentProject)
+            .sink { [weak self] project in
+                self?.currentProject = project
+            }
     }
 
     private func sendBillToServer(bill: Bill, update: Bool, completion: @escaping () -> Void) {
@@ -235,6 +238,7 @@ extension ProjectManager {
         }) else {
             return
         }
+        loadCancellable?.cancel()
         currentProject = project
         loadBillsAndMembers()
         defaults.set(project.id, forKey: "projectID")

--- a/PayForMe/Views/Balance/BalanceList.swift
+++ b/PayForMe/Views/Balance/BalanceList.swift
@@ -21,9 +21,6 @@ struct BalanceList: View {
         NavigationView {
             mainView
                 .navigationBarTitle("Members")
-                .onAppear {
-                    ProjectManager.shared.loadBillsAndMembers()
-                }
         }.navigationViewStyle(StackNavigationViewStyle())
     }
 
@@ -51,6 +48,9 @@ struct BalanceList: View {
                     BalanceCell(balance: balance)
                 }
             }
+        }
+        .refreshable {
+            await ProjectManager.shared.refresh()
         }
     }
 

--- a/PayForMe/Views/Balance/BalanceList.swift
+++ b/PayForMe/Views/Balance/BalanceList.swift
@@ -94,8 +94,7 @@ struct BalanceList_Previews: PreviewProvider {
 }
 
 struct BalanceCell: View {
-    @State
-    var balance: Balance
+    let balance: Balance
 
     var body: some View {
         HStack {

--- a/PayForMe/Views/BillDetail/WhoPaidView.swift
+++ b/PayForMe/Views/BillDetail/WhoPaidView.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct WhoPaidView: View {
-    @State
-    var members: [Person]
+    let members: [Person]
 
     @Binding
     var selectedPayer: Int

--- a/PayForMe/Views/BillList/BillCell.swift
+++ b/PayForMe/Views/BillList/BillCell.swift
@@ -11,14 +11,13 @@ struct BillCell: View {
     @ObservedObject
     var viewModel: BillListViewModel
 
-    @State
-    var bill: Bill
+    let bill: Bill
 
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 10) {
                 Text(bill.what).font(.headline)
-                PersonsView(bill: $bill, members: $viewModel.currentProject.members)
+                PersonsView(bill: bill, members: viewModel.currentProject.members)
             }
             Spacer()
             VStack(alignment: .trailing, spacing: 10) {

--- a/PayForMe/Views/BillList/BillList.swift
+++ b/PayForMe/Views/BillList/BillList.swift
@@ -20,7 +20,6 @@ struct BillList: View {
                 iOS15ListContent
             }
             .addFloatingAddButton()
-            .id(viewModel.currentProject.bills)
             .navigationBarTitle("Bills")
             .alert(item: $deleteAlert) { index in
                 Alert(title: Text("Delete Bill"),

--- a/PayForMe/Views/BillList/BillList.swift
+++ b/PayForMe/Views/BillList/BillList.swift
@@ -20,6 +20,9 @@ struct BillList: View {
                 iOS15ListContent
             }
             .addFloatingAddButton()
+            .refreshable {
+                await ProjectManager.shared.refresh()
+            }
             .navigationBarTitle("Bills")
             .alert(item: $deleteAlert) { index in
                 Alert(title: Text("Delete Bill"),
@@ -30,9 +33,6 @@ struct BillList: View {
                       secondaryButton: .cancel())
             }
             .listStyle(InsetGroupedListStyle())
-        }
-        .onAppear {
-            ProjectManager.shared.loadBillsAndMembers()
         }
     }
 

--- a/PayForMe/Views/BillList/BillListViewModel.swift
+++ b/PayForMe/Views/BillList/BillListViewModel.swift
@@ -27,9 +27,9 @@ class BillListViewModel: ObservableObject {
     init() {
         currentProject = manager.currentProject
         cancellable = currentProjectChanged
-        $sortBy
-            .map {
-                $0.sort(bills: self.currentProject.bills)
+        Publishers.CombineLatest($sortBy, $currentProject)
+            .map { sortBy, project in
+                sortBy.sort(bills: project.bills)
             }
             .assign(to: &$sortedBills)
     }

--- a/PayForMe/Views/BillList/PersonsView.swift
+++ b/PayForMe/Views/BillList/PersonsView.swift
@@ -8,11 +8,8 @@
 import SwiftUI
 
 struct PersonsView: View {
-    @Binding
-    var bill: Bill
-
-    @Binding
-    var members: [Int: Person]
+    let bill: Bill
+    let members: [Int: Person]
 
     var body: some View {
         HStack(spacing: 5) {

--- a/PayForMe/Views/ContentView.swift
+++ b/PayForMe/Views/ContentView.swift
@@ -12,6 +12,12 @@ struct ContentView: View {
     @ObservedObject
     var manager = ProjectManager.shared
 
+    @StateObject
+    private var billListViewModel = BillListViewModel()
+
+    @StateObject
+    private var balanceViewModel = BalanceViewModel()
+
     @State
     var tabBarIndex = tabBarItems.BillList
 
@@ -36,12 +42,12 @@ struct ContentView: View {
 
     var tabBar: some View {
         TabView(selection: $tabBarIndex) {
-            BillList(viewModel: BillListViewModel())
+            BillList(viewModel: billListViewModel)
                 .tabItem {
                     Image(systemName: "rectangle.stack")
                 }
                 .tag(tabBarItems.BillList)
-            BalanceList(viewModel: BalanceViewModel())
+            BalanceList(viewModel: balanceViewModel)
                 .tabItem {
                     Image(systemName: "arrow.right.arrow.left")
                 }

--- a/PayForMe/Views/ContentView.swift
+++ b/PayForMe/Views/ContentView.swift
@@ -18,6 +18,9 @@ struct ContentView: View {
     @StateObject
     private var balanceViewModel = BalanceViewModel()
 
+    @Environment(\.scenePhase)
+    private var scenePhase
+
     @State
     var tabBarIndex = tabBarItems.BillList
 
@@ -37,6 +40,11 @@ struct ContentView: View {
         }
         .sheet(item: $manager.openedByURL) { url in
             AddFromURLView(viewmodel: AddProjectQRViewModel(openedByURL: url))
+        }
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active && !manager.projects.isEmpty {
+                manager.loadBillsAndMembers()
+            }
         }
     }
 

--- a/PayForMe/Views/PersonText.swift
+++ b/PayForMe/Views/PersonText.swift
@@ -8,8 +8,7 @@
 import SwiftUI
 
 struct PersonText: View {
-    @State
-    var person: Person
+    let person: Person
 
     var body: some View {
         Text(person.name)

--- a/PayForMe/Views/Projects/QRCodes/AddProjectQRViewModel.swift
+++ b/PayForMe/Views/Projects/QRCodes/AddProjectQRViewModel.swift
@@ -27,8 +27,12 @@ class AddProjectQRViewModel: ObservableObject {
 
     init() {
         foundCodeSink.store(in: &subscriptions)
-        passwordCorrect.assign(to: &$isProject)
-        isTestingSubject.assign(to: &$isProject)
+        passwordCorrect
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$isProject)
+        isTestingSubject
+            .receive(on: DispatchQueue.main)
+            .assign(to: &$isProject)
     }
 
     convenience init(openedByURL: URL?) {
@@ -90,6 +94,7 @@ class AddProjectQRViewModel: ObservableObject {
 
     var foundCodeSink: AnyCancellable {
         foundCode
+            .receive(on: DispatchQueue.main)
             .sink { codedUrl in
                 let projectData = codedUrl.decodeQRCode()
                 guard let url = projectData.server, let token = projectData.project else { return }

--- a/PayForMeTests/NetworkRequestTests.swift
+++ b/PayForMeTests/NetworkRequestTests.swift
@@ -109,6 +109,24 @@ class NetworkRequestTests: XCTestCase {
                       "Cospend must embed token and password. Got: \(url)")
     }
 
+    func testCospend_loadBills_trailingSlashInServerURL_doesNotProduceDoubleSlash() {
+        let project = Project.makeCospend(token: "tok", password: "pass",
+                                          url: "https://cloud.example.com/")
+        MockURLProtocol.requestHandler = jsonHandler()
+
+        let exp = expectation(description: "request intercepted")
+        NetworkService.shared.loadBillsPublisher(project)
+            .sink { _ in exp.fulfill() }
+            .store(in: &subscriptions)
+        waitForExpectations(timeout: 2)
+
+        let url = MockURLProtocol.lastCapturedRequest?.url?.absoluteString ?? ""
+        XCTAssertFalse(url.contains("com//"),
+                       "Server URL with trailing slash must not produce a double slash. Got: \(url)")
+        XCTAssertTrue(url.contains("/index.php/apps/cospend/api/projects/tok/pass/bills"),
+                      "Cospend path must remain correct with trailing-slash server URL. Got: \(url)")
+    }
+
     // MARK: - Cospend: no auth header
 
     func testCospend_loadBills_noAuthorizationHeader() {


### PR DESCRIPTION
I could finally reproduce the 429 myself and went digging. The fix from #92 only touched the validate-while-typing path, but the regular bills/members loader had its own request-burst problem: every `onAppear`, every mutation, every tab switch fired a fresh Combine pipeline without cancelling the previous one, and a server URL ending in / produced a double slash (https://host//index.php/...) which openresty seems to rate-limit as a separate path.

I removed the leading / from staticPath, made `loadBillsAndMembers` single-flight (cancel-and-replace via one `AnyCancellable`), put the tab view models behind `@StateObject` so they don't get re-allocated on every render, and replaced the `.onAppear` reloads on the bills and balance tab with `.refreshable` plus a refresh on scenePhase becoming active.

While I was at it, a few related bugs got in the way of confirming the fix: `sortedBills` wasn't reacting to new bills (only watching `$sortBy`), and four views had `@State` on input properties (BalanceCell, BillCell, WhoPaidView, PersonText) which is why balances and edited bills only updated after reopening the project. Also fixed two background-thread `@Published` writes that showed up in the console (mutation completion handlers and the QR scan publisher).

Until another occurrence, this merge actually closes #81.