### PR TITLE
register i-hate-money url scheme

### DIFF
--- a/PayForMe/Info.plist
+++ b/PayForMe/Info.plist
@@ -30,6 +30,16 @@
 				<string>cospend</string>
 			</array>
 		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>de.mayflower.PayForMe.ihatemoney</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ihatemoney</string>
+			</array>
+		</dict>
 	</array>
 	<key>CFBundleVersion</key>
 	<string>114</string>


### PR DESCRIPTION
fixes #96 

PayForMe was not able to open the app when a QR code was scanned with the camera app. I forgot to commit the url scheme registration in PR #93 . Any business logic regarding registration should already be present.